### PR TITLE
Improve tests

### DIFF
--- a/docker/salt-sle11sp4/Dockerfile
+++ b/docker/salt-sle11sp4/Dockerfile
@@ -1,7 +1,7 @@
 # Container used to test cobbler against suse manager head
 #
 # NAME                  salt-sle11sp4
-# VERSION               1.0.0
+# VERSION               1.0.1
 
 FROM suma-docker-registry.suse.de/sles11sp4:0.1.0
 MAINTAINER Michael Calmer "mc@suse.com"

--- a/docker/salt-sle11sp4/add_packages.sh
+++ b/docker/salt-sle11sp4/add_packages.sh
@@ -9,7 +9,7 @@ zypper -n in  --no-recommends iproute2 \
                               python \
                               cron \
                               sysconfig \
-                              python-pyOpenSSL \
+                              python-openssl \
                               postfix \
                               psmisc \
                               udev \
@@ -22,7 +22,6 @@ zypper -n in  --no-recommends iproute2 \
                               bind-utils
 
 # required for unit tests install with recommends
-zypper -n in quilt
-#zypper -n in quilt rpm-build
+zypper -n in quilt tar
 
 zypper -n in vim less

--- a/docker/salt-sle11sp4/add_repositories.sh
+++ b/docker/salt-sle11sp4/add_repositories.sh
@@ -1,18 +1,12 @@
 #!/bin/bash
 set -e
 
-zypper ar -f http://download.suse.de/ibs/SUSE:/SLE-11:/GA/standard "SLE11 GA"
-zypper ar -f http://download.suse.de/ibs/SUSE:/SLE-11:/Update/standard/ "SLE11 Updates"
-zypper ar -f http://download.suse.de/ibs/SUSE:/SLE-11-SP1:/GA/standard "SLE11 SP1 GA"
-zypper ar -f http://download.suse.de/ibs/SUSE:/SLE-11-SP1:/Update/standard "SLE11 SP1 Updates"
-zypper ar -f http://download.suse.de/ibs/SUSE:/SLE-11-SP2:/GA/standard "SLE11 SP2 GA"
-zypper ar -f http://download.suse.de/ibs/SUSE:/SLE-11-SP2:/Update/standard "SLE11 SP2 Updates"
-zypper ar -f http://download.suse.de/ibs/SUSE:/SLE-11-SP3:/GA/standard "SLE11 SP3 GA"
-zypper ar -f http://download.suse.de/ibs/SUSE:/SLE-11-SP3:/Update/standard "SLE11 SP3 Updates"
-zypper ar -f http://download.suse.de/ibs/SUSE:/SLE-11-SP4:/GA/standard "SLE11 SP4 GA"
-zypper ar -f http://download.suse.de/ibs/SUSE:/SLE-11-SP4:/Update/standard "SLE11 SP4 Updates"
+zypper ar -f 'http://nu.novell.com/repo/$RCE/SLES11-SP4-Pool/sle-11-x86_64/' "SLES11 SP4 Pool"
+zypper ar -f 'http://nu.novell.com/repo/$RCE/SLES11-SP4-Updates/sle-11-x86_64/' "SLES11 SP4 Updates"
+zypper ar -f 'http://nu.novell.com/repo/$RCE/SLE11-SDK-SP4-Pool/sle-11-x86_64' "SLE-SDK11 SP4 Pool"
+zypper ar -f 'http://nu.novell.com/repo/$RCE/SLE11-SDK-SP4-Updates/sle-11-x86_64' "SLE-SDK11 SP4 Updates"
 
 zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/saltstack/SLE_11_SP4/ "salt"
 zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/testing/SLE_11_SP4/ "salt_testing"
-zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/testing:/testpackages/SLE_11_SP4/ "salt_testing_pkg"
+zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/testing:/testpackages/SLE_11_SP4/ "testpackages"
 

--- a/docker/salt-sle11sp4/add_repositories.sh
+++ b/docker/salt-sle11sp4/add_repositories.sh
@@ -10,3 +10,4 @@ zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/saltst
 zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/testing/SLE_11_SP4/ "salt_testing"
 zypper ar -f http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/testing:/testpackages/SLE_11_SP4/ "testpackages"
 
+zypper mr -p 98 salt_testing

--- a/tests/test_grains.sh
+++ b/tests/test_grains.sh
@@ -26,41 +26,50 @@ else
     msg="No /etc/os-release file found."
     skip_tests "\${msg}"
 fi
+source /etc/os-release
+
+# list all grains
+CMD="grains.items"
+INFO="list all grains"
+describe "\${CMD}" "\${INFO}"
+$SALT_CALL $CMD --out json
+assert_run
 
 # OS family
 CMD="grains.get os_family"
-INFO="Verify OS family"
+INFO="Verify OS family is Suse"
 describe "\${CMD}" "\${INFO}"
 $SALT_CALL $CMD --out json | bin/jsontest path=$HOST type=s contains="Suse"
 assert_run
 
 # OS code name (pretty name)
 CMD="grains.get oscodename"
-INFO="Verify OS code name (pretty name)"
+INFO="Verify OS code name (pretty name) is $PRETTY_NAME"
 describe "\${CMD}" "\${INFO}"
-$SALT_CALL $CMD --out json | bin/jsontest path=$HOST type=s contains=$(cat /etc/os-release | grep PRETTY | sed -e 's/\"//g' | sed -e 's/.*=//')
+$SALT_CALL $CMD --out json | bin/jsontest path=$HOST type=s contains=$PRETTY_NAME
 assert_run
 
 
 # OS full name
 CMD="grains.get osfullname"
-INFO="Verify OS full name"
+INFO="Verify OS full name is $NAME"
 describe "\${CMD}" "\${INFO}"
-$SALT_CALL $CMD --out json | bin/jsontest path=$HOST type=s contains=$(cat /etc/os-release | grep '^NAME' | sed -e 's/.*=//' | sed -e 's/"//g')
+$SALT_CALL $CMD --out json | bin/jsontest path=$HOST type=s contains=$NAME
 assert_run
 
 # OS architecture (not CPU arch!)
 CMD="grains.get osarch"
-INFO="Verify package architecture"
+INFO="Verify package architecture is $(rpm --eval %{_host_cpu})"
 describe "\${CMD}" "\${INFO}"
 $SALT_CALL $CMD --out json | bin/jsontest path=$HOST type=s contains=$(rpm --eval %{_host_cpu})
 assert_run
 
+
 # OS version (don't try that at home)
 CMD="grains.get osrelease"
-INFO="Verify OS release"
+INFO="Verify OS release is $VERSION_ID"
 describe "\${CMD}" "\${INFO}"
-$SALT_CALL $CMD --out json | bin/jsontest path=$HOST type=s contains=$(cat /etc/SuSE-release | sed ':a;N;$!ba;s/\n/ /g' | awk '{print $9"."$12}')
+$SALT_CALL $CMD --out json | bin/jsontest path=$HOST type=s contains=$VERSION_ID
 assert_run
 
 # OS release info

--- a/tests/test_grains.sh
+++ b/tests/test_grains.sh
@@ -78,5 +78,5 @@ INFO="Verify OS release"
 describe "\${CMD}" "\${INFO}"
 MAJOR=$(cat /etc/SuSE-release | grep VERSION | awk '{print $3}')
 MINOR=$(cat /etc/SuSE-release | grep PATCHLEVEL | awk '{print $3}')
-[ "2" != $($SALT_CALL $CMD --out json | grep "$MAJOR\|$MINOR" | wc -l) ]
+[ "2" == $($SALT_CALL $CMD --out json | grep -v $HOSTNAME | grep "$MAJOR\|$MINOR" | wc -l) ]
 assert_run

--- a/tests/test_version_cmp.sh
+++ b/tests/test_version_cmp.sh
@@ -30,7 +30,7 @@ version_test '0.2-1' '1:0.2-1' '-1'
 version_test '1:0.2-1' '0.2-1' '1'
 
 . /etc/os-release
-if [ ${VERSION%.*} -ge 12 ]; then
+if [ ${VERSION_ID%.*} -ge 12 ]; then
     # ~ has a special meaning since SLE12
     version_test '0.2-1' '0.2~beta1-1' '1'
     version_test '0.2~beta2-1' '0.2-1' '-1'

--- a/tests/test_version_cmp.sh
+++ b/tests/test_version_cmp.sh
@@ -28,6 +28,14 @@ version_test '0.2-1.0' '0.2-1' '1'
 version_test '0.2.0-1' '0.2-1' '1'
 version_test '0.2-1' '1:0.2-1' '-1'
 version_test '1:0.2-1' '0.2-1' '1'
-version_test '0.2-1' '0.2~beta1-1' '1'
-version_test '0.2~beta2-1' '0.2-1' '-1'
+
+. /etc/os-release
+if [ ${VERSION%.*} -ge 12 ]; then
+    # ~ has a special meaning since SLE12
+    version_test '0.2-1' '0.2~beta1-1' '1'
+    version_test '0.2~beta2-1' '0.2-1' '-1'
+else
+    version_test '0.2-1' '0.2~beta1-1' '-1'
+    version_test '0.2~beta2-1' '0.2-1' '1'
+fi
 

--- a/tests/test_zypper.sh
+++ b/tests/test_zypper.sh
@@ -96,7 +96,7 @@ echo "$JSONOUT" | bin/jsontest path={"$HOST","test-package-zypper","summary"} \
 assert_run
 
 . /etc/os-release
-if [ ${VERSION%.*} -ge 12 ]; then
+if [ ${VERSION_ID%.*} -ge 12 ]; then
     # download only available since SLE12
 
     # download

--- a/tests/test_zypper.sh
+++ b/tests/test_zypper.sh
@@ -95,13 +95,18 @@ echo "$JSONOUT" | bin/jsontest path={"$HOST","test-package-zypper","summary"} \
     type=s value="Test package for Salt's pkg.latest"
 assert_run
 
-# download
-CMD="pkg.download test-package"
-INFO="Test download"
-describe "\${CMD}" "\${INFO}"
-$SALT_CALL $CMD --out json | bin/jsontest path={"$HOST","test-package","repository-alias"} \
-    type=s value="salt"
-assert_run
+. /etc/os-release
+if [ ${VERSION%.*} -ge 12 ]; then
+    # download only available since SLE12
+
+    # download
+    CMD="pkg.download test-package"
+    INFO="Test download"
+    describe "\${CMD}" "\${INFO}"
+    $SALT_CALL $CMD --out json | bin/jsontest path={"$HOST","test-package","repository-alias"} \
+        type=s value="salt"
+    assert_run
+fi
 
 # remove pkg
 CMD="pkg.remove test-package"


### PR DESCRIPTION
Make tests work on SLE11

@isbm Maybe we need to look into pkg.download. The used zypper command does not exist in SLE11. For now I have disabled this test in SLE11 but maybe we find an implementation which works also there.

Please check also the salt package. I added new patches but I re-created one of yours. It was not included in the package and had a lot of unrelated code.